### PR TITLE
Filenames cleaned

### DIFF
--- a/msfs_geoshot/gui/controller.py
+++ b/msfs_geoshot/gui/controller.py
@@ -1,3 +1,4 @@
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -95,6 +96,8 @@ class ScreenShotController(QObject):
             date_format=self._settings.date_format,
             metadata=metadata,
         )
+        # clean of illegal filename characters
+        screenshot_name = re.sub(r"[/\\?%*:|\"<>\x7F\x00-\x1F]", "_", screenshot_name)
         # avoid hitting Windows file name length limit
         truncated_name = screenshot_name[:250]
 


### PR DESCRIPTION
Firstly, thanks for creating this!

I ran into an issue where I wouldn't take the screenshot, I think because the "place name" had illegal (for filename) characters in it. This is a quick patch to replace any illegal characters with an underscore.

If you want to test this yourself, I was just outside CZAM.

This is the error message I got:

```
MSFS GeoShot encountered an error. Please report this message on GitHub or in the official support thread.


Traceback (most recent call last):
  File "C:\Program Files\MSFS GeoShot\MSFS_GeoShot.launch.pyw", line 34, in 
    from msfs_geoshot import __main__
  File "", line 1058, in _handle_fromlist
  File "", line 228, in _call_with_frames_removed
  File "", line 1007, in _find_and_load
  File "", line 986, in _find_and_load_unlocked
  File "", line 680, in _load_unlocked
  File "", line 850, in exec_module
  File "", line 228, in _call_with_frames_removed
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\__main__.py", line 7, in 
    sys.exit(run())
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\app.py", line 127, in run
    return app.exec()
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\gui\hotkeys.py", line 21, in nativeEventFilter
    ret = self.keybinder.handler(eventType, message)
  File "C:\Program Files\MSFS GeoShot\pkgs\pyqtkeybind\win\__init__.py", line 71, in handler
    cb()
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\gui\hotkeys.py", line 52, in 
    window_id, key, lambda: self.send_hotkey_signal(hotkey_id)
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\gui\hotkeys.py", line 81, in send_hotkey_signal
    signal.emit()
  File "C:\Program Files\MSFS GeoShot\pkgs\msfs_geoshot\gui\controller.py", line 102, in take_screenshot
    screenshot_path.with_stem(truncated_name)
  File "pathlib.py", line 889, in with_stem
  File "pathlib.py", line 883, in with_name
ValueError: Invalid name 'MSFS_2022-05-05-221352_Canada-British_Columbia-Regional_District_of_North_Okanagan-Area_F_(Grindrod/Ashton_Creek/Mabel_Lake).jpg'
```

I haven't been able to build the program myself (yet?) as I don't have bash installed on my Windows machine. Hopefully it's simple on your side to push a release.