### PR TITLE
Fix MSFS 2024 compatibility: support FlightSimulator2024.exe process name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@
 
 GeoShot is a **screenshot** tool for **Microsoft Flight Simulator**. It allows users to create metadata-enriched screenshots of their flights, enabling use cases such as keeping track of screenshot locations via **geotags**.
 
+## MSFS 2024 Support
+
+This fork adds compatibility with **Microsoft Flight Simulator 2024**.
+The original tool only detected `FlightSimulator.exe` (MSFS 2020). This fork
+also detects `FlightSimulator2024.exe`, making it work with both versions.
+
+### Running from source (MSFS 2020 or 2024)
+
+**Requirements:** Python 3.9+, 64-bit Windows
+```bash
+git clone https://github.com/fitzroymckay/msfs-geoshot.git
+cd msfs-geoshot
+python -m venv .venv
+.venv\Scripts\activate
+pip install SimConnect psutil PyQt5 multiexit piexif requests Pillow pywin32 pyqt5-tools
+pyuic5 qtdesigner\feedback.ui -o msfs_geoshot\gui\forms\feedback.py
+pyuic5 qtdesigner\main_window.ui -o msfs_geoshot\gui\forms\main_window.py
+New-Item msfs_geoshot\gui\forms\__init__.py -Type File
+python -m msfs_geoshot
+```
+
+Start MSFS 2024 and load into a flight before running the tool.
+
 ## Screenshots
 
 *Interface*

--- a/msfs_geoshot/sim.py
+++ b/msfs_geoshot/sim.py
@@ -62,11 +62,16 @@ _nullable_sim_data: Set[str] = set(("dest_latitude", "dest_longitude", "aircraft
 
 class SimService:
 
-    _sim_executable = "FlightSimulator.exe"
+    _sim_executables = {"FlightSimulator.exe", "FlightSimulator2024.exe"}
     _sim_window_title = "Microsoft Flight Simulator"
 
+    def _get_running_sim_executable(self) -> Optional[str]:
+        running_names = {p.name() for p in psutil.process_iter()}
+        found = self._sim_executables & running_names
+        return found.pop() if found else None
+
     def _is_sim_running(self) -> bool:
-        return self._sim_executable in (p.name() for p in psutil.process_iter())
+        return self._get_running_sim_executable() is not None
 
     def _is_user_in_flight(self, sim_location_data: _SimData) -> bool:
         return not (
@@ -76,7 +81,10 @@ class SimService:
         )
 
     def get_simulator_main_window_id(self) -> int:
-        window_ids = get_window_ids_by_process_name(self._sim_executable)
+        exe = self._get_running_sim_executable()
+        if not exe:
+            raise SimServiceError("Could not find simulator window.")
+        window_ids = get_window_ids_by_process_name(exe)
         results: List[int] = []
         for window_id in window_ids:
             if self._sim_window_title in get_window_title_by_window_id(window_id):
@@ -109,7 +117,6 @@ class SimService:
             dest_longitude=aircraft_requests.get("GPS_WP_NEXT_LON"),
             aircraft_type=aircraft_requests.get("TITLE"),
         )
-        # TITLE
 
         sim_connect.exit()
 


### PR DESCRIPTION
## Problem
MSFS GeoShot does not work with Microsoft Flight Simulator 2024 because the 
sim detection logic hardcodes the process name `FlightSimulator.exe`, which 
was renamed to `FlightSimulator2024.exe` in the 2024 release.

This causes two failures:
- `_is_sim_running()` always returns False, blocking SimConnect entirely
- `get_simulator_main_window_id()` cannot find the window for screenshots

## Fix
- Replaced the single `_sim_executable` string with a `_sim_executables` set 
  containing both process names
- Added `_get_running_sim_executable()` helper that checks for either process
- Updated `_is_sim_running()` and `get_simulator_main_window_id()` to use it

This keeps full backward compatibility with MSFS 2020 while adding MSFS 2024 
support. Tested and confirmed working on MSFS 2024.

## Notes
- The window title check (`"Microsoft Flight Simulator" in title`) already 
  works for both versions via substring match, so no change was needed there
- SimConnect variables (GPS_POSITION_LAT etc.) are identical in both sims